### PR TITLE
Laravel 6 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^7.1.3",
         "florianv/swap": "^4.0",
-        "cache/illuminate-adapter": "^0.2.0",
+        "amodar/illuminate-adapter": "^0.2.1",
         "cache/simple-cache-bridge": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
cache/illuminate-adapter does not support laravel 6 and is unfortunately set to read-only. I've forked the repo (amodar/illuminate-adapter) and adjusted the composer file to support Laravel 6.