### PR TITLE
[Review Required] Drop cache adapter support with Laravel 5.8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 vendor
 bin/
 .php_cs.cache
+.phpunit.*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Swap allows you to retrieve currency exchange rates from various services such a
 $ composer require php-http/curl-client nyholm/psr7 php-http/message florianv/laravel-swap
 ```
 
+### Laravel 5.7 or lesser
+
+If you use cache, add also cache adapter dependencies :
+
+```bash
+$ composer require cache/illuminate-adapter cache/simple-cache-bridge
+```
+
+These dependencies are not required with Laravel 5.8 or greater.
+
 ### Laravel 5.5+
 
 If you don't use auto-discovery, add the `ServiceProvider` to the providers array in `config/app.php`:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ $ composer require php-http/curl-client nyholm/psr7 php-http/message florianv/la
 
 ### Laravel 5.7 or lesser
 
-If you use cache, add also cache adapter dependencies :
+If you use cache, add also PSR-6 adapter and PSR-16 bridge cache dependencies :
 
 ```bash
 $ composer require cache/illuminate-adapter cache/simple-cache-bridge
 ```
 
-These dependencies are not required with Laravel 5.8 or greater.
+These dependencies are not required with Laravel 5.8 or greater which [implements PSR-16](https://github.com/laravel/framework/pull/27217).
 
 ### Laravel 5.5+
 

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,10 @@
     },
     "require": {
         "php": "^7.1.3",
-        "florianv/swap": "^4.0",
-        "cache/illuminate-adapter": "^0.2.0",
-        "cache/simple-cache-bridge": "^1.0"
+        "florianv/swap": "^4.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "~5.2",
+        "graham-campbell/testbench": "^5.3",
         "php-http/guzzle6-adapter": "^1.0",
         "nyholm/psr7": "^1.0"
     },

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -56,6 +56,16 @@ Copy the package config to your local config with the publish command:
 $ php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
 ```
 
+__Laravel 5.7 or lesser :__
+
+If you use cache, add also PSR-6 adapter and PSR-16 bridge cache dependencies :
+
+```bash
+$ composer require cache/illuminate-adapter cache/simple-cache-bridge
+```
+
+These dependencies are not required with Laravel 5.8 or greater which [implements PSR-16](https://github.com/laravel/framework/pull/27217).
+
 ### Lumen
 
 Configure the Service Provider and alias:

--- a/src/SwapServiceProvider.php
+++ b/src/SwapServiceProvider.php
@@ -99,9 +99,11 @@ final class SwapServiceProvider extends ServiceProvider
     private function getSimpleCache()
     {
         if ($cache = $this->app->config->get('swap.cache')) {
-            $store = $this->app['cache']->store($cache)->getStore();
+            $store = $this->app['cache']->store($cache);
 
-            return new SimpleCacheBridge(new IlluminateCachePool($store));
+            return $store instanceof \Psr\SimpleCache\CacheInterface
+                ? $store
+                : new SimpleCacheBridge(new IlluminateCachePool($store->getStore()));
         }
 
         return null;

--- a/src/SwapServiceProvider.php
+++ b/src/SwapServiceProvider.php
@@ -101,9 +101,24 @@ final class SwapServiceProvider extends ServiceProvider
         if ($cache = $this->app->config->get('swap.cache')) {
             $store = $this->app['cache']->store($cache);
 
-            return $store instanceof \Psr\SimpleCache\CacheInterface
-                ? $store
-                : new SimpleCacheBridge(new IlluminateCachePool($store->getStore()));
+            // Check simple cache PSR-16 compatibility
+            if ($store instanceof \Psr\SimpleCache\CacheInterface) {
+                return $store;
+            }
+
+            // Ensure PSR-6 adapter class exists
+            if (! class_exists(IlluminateCachePool::class)) {
+                throw new \Exception("cache/illuminate-adapter dependency is missing");
+            }
+
+            // Ensure PSR-16 bridge class exists
+            if (! class_exists(SimpleCacheBridge::class)) {
+                throw new \Exception("cache/simple-cache-bridge dependency is missing");
+            }
+
+            return new SimpleCacheBridge(
+                new IlluminateCachePool($store->getStore())
+            );
         }
 
         return null;

--- a/tests/SwapServiceProviderTest.php
+++ b/tests/SwapServiceProviderTest.php
@@ -21,12 +21,11 @@ class SwapServiceProviderTest extends AbstractTestCase
 {
     use ServiceProviderTrait;
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "access_key" option must be provided.
-     */
     public function testMissingServiceConfig()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "access_key" option must be provided.');
+
         $this->app->config->set('swap.services', [
             'currency_layer' => true,
         ]);
@@ -34,12 +33,11 @@ class SwapServiceProviderTest extends AbstractTestCase
         $this->app['swap'];
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The service "unknown" is not registered.
-     */
     public function testUnknownService()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The service "unknown" is not registered.');
+
         $this->app->config->set('swap.services', [
             'unknown' => true,
         ]);
@@ -49,7 +47,7 @@ class SwapServiceProviderTest extends AbstractTestCase
 
     public function testEmptyServices()
     {
-        $this->app['swap'];
+        Assert::assertInstanceOf(Swap::class, $this->app['swap']);
     }
 
     public function testSwapIsInjectable()


### PR DESCRIPTION
Disclaimer : It is a proposition only, i am not sure if it is the way to go.

Since Laravel 5.8, cache repository instance implements `\Psr\SimpleCache\CacheInterface`, so (if i am not wrong) does not require simple cache bridge anymore.

This PR is an attempt to drop these dependencies (by default) and also add support for Laravel 6.

For Laravel 5.7 or lesser it should simply require to add `cache/illuminate-adapter` and `cache/simple-cache-bridge` dependencies using composer. (i edited readme file to reflect theses changes).

If you disagree, simply close this PR. If it require some changes, just let me know !