### PR TITLE
chore: add facade-documenter to keep Swap facade PHPDoc in sync

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,27 @@
+name: Code Style
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Lint facade docblocks
+        run: php -f vendor/bin/facade.php Swap\\Laravel\\Facades\\Swap

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     ],
     "scripts": {
         "test": "vendor/bin/phpunit",
+        "facade:fix": "php -f vendor/bin/facade.php Swap\\Laravel\\Facades\\Swap --write",
         "facade:lint": "php -f vendor/bin/facade.php Swap\\Laravel\\Facades\\Swap",
         "psalm": "vendor/bin/psalm --no-progress",
         "cs:fix": "vendor/bin/php-cs-fixer fix --no-interaction --ansi --quiet",

--- a/composer.json
+++ b/composer.json
@@ -36,14 +36,23 @@
     },
     "require-dev": {
         "graham-campbell/testbench": "^6.2",
+        "laravel/facade-documenter": "dev-main",
         "phpunit/phpunit": "^11.0 || ^12.0",
         "vimeo/psalm": "^6.0",
         "roave/backward-compatibility-check": "^8.9",
         "php-http/guzzle7-adapter": "^1.0",
         "nyholm/psr7": "^1.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/laravel/facade-documenter.git",
+            "name": "facade-documenter"
+        }
+    ],
     "scripts": {
         "test": "vendor/bin/phpunit",
+        "facade:lint": "php -f vendor/bin/facade.php Swap\\Laravel\\Facades\\Swap",
         "psalm": "vendor/bin/psalm --no-progress",
         "cs:fix": "vendor/bin/php-cs-fixer fix --no-interaction --ansi --quiet",
         "cs:check": "vendor/bin/php-cs-fixer fix --no-interaction --ansi --verbose --dry-run"

--- a/src/Facades/Swap.php
+++ b/src/Facades/Swap.php
@@ -3,9 +3,6 @@
 /*
  * This file is part of Laravel Swap.
  *
- * @method static \Exchanger\Contract\ExchangeRate latest (string $currencyPair, array $options = [])
- * @method static \Exchanger\Contract\ExchangeRate historical (string $currencyPair, \DateTimeInterface $date, array $options = [])
- *
  * (c) Florian Voutzinos <florian@voutzinos.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -17,9 +14,10 @@ namespace Swap\Laravel\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * Facade for Swap.
+ * @method static \Exchanger\Contract\ExchangeRate latest(string $currencyPair, array $options = [])
+ * @method static \Exchanger\Contract\ExchangeRate historical(string $currencyPair, \DateTimeInterface $date, array $options = [])
  *
- * @author Florian Voutzinos <florian@voutzinos.com>
+ * @see \Swap\Swap
  */
 final class Swap extends Facade
 {


### PR DESCRIPTION
## Summary

- Move `@method` annotations from file header comment to the class docblock (where they belong)
- Add `@see \Swap\Swap` to link the facade to its underlying class
- Add `laravel/facade-documenter` as a dev dependency with CI lint step to ensure the facade PHPDoc stays in sync with the underlying `Swap` class

This follows the same approach used in [laravel-geoip](https://github.com/InteractionDesignFoundation/laravel-geoip/commit/34dde6cf8b1d0d27429639d9eb14ef4918420c8d).

## Changes

- **`src/Facades/Swap.php`** — Moved `@method` tags into the class docblock, added `@see`, removed stale file-header annotations
- **`composer.json`** — Added `laravel/facade-documenter` dev dep, VCS repository, and `facade:lint` script
- **`.github/workflows/style.yml`** — New CI workflow that lints facade docblocks on push/PR