### PR TITLE
Improve README, documentation, and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 > _Drop-in currency conversion for Laravel and Lumen. Auto-discovered service provider, facade, and config. Maintained since 2014._
 
-Laravel Swap is a drop-in **Laravel currency conversion** package. Install it, get a facade, and start fetching exchange rates. Auto-discovery wires the service provider in Laravel 5.5+; configuration publishes to `config/swap.php`; rates are cached through the Laravel cache store you already have. Lumen is supported. Used in real-world Laravel applications since 2014.
+**Install, publish the config, and call `Swap::latest('EUR/USD')` from anywhere. No service container wiring, no boilerplate, no manual cache plumbing.**
+
+Laravel Swap is a drop-in package for **Laravel currency conversion**. Install it, get a facade, and start fetching **Laravel exchange rates** from multiple providers in one call. The service provider is auto-discovered in Laravel 5.5+; configuration publishes to `config/swap.php`; rates are cached through the Laravel cache store you already have. Lumen is supported. Used in real-world Laravel applications since 2014.
 
 ## 💡 What is Laravel Swap?
 
@@ -25,6 +27,10 @@ Laravel Swap is a drop-in **Laravel currency conversion** package. Install it, g
 
 ## 🧠 Why Laravel Swap and not raw Swap?
 
+Using [Swap](https://github.com/florianv/swap) directly inside a Laravel app means three pieces of plumbing on every project: registering it in the service container, bridging your Laravel cache store to the PSR-16 contract Swap expects, and managing the HTTP client and PSR factories yourself. Doable, but boilerplate every project pays for.
+
+Laravel Swap does this for you:
+
 - **Drop-in.** Auto-discovery in Laravel 5.5+. No manual provider or alias registration.
 - **Laravel cache integration.** Rates are cached through the cache store you already configured (`file`, `redis`, `database`, etc.), no PSR-16 wiring required.
 - **Facade.** `Swap::latest('EUR/USD')` from anywhere in the app.
@@ -41,11 +47,15 @@ Laravel Swap requires PHP 8.2 or newer.
 composer require florianv/laravel-swap symfony/http-client nyholm/psr7
 ```
 
-`symfony/http-client` and `nyholm/psr7` provide the PSR-18 HTTP client and PSR-17 factories. Any PSR-18 / PSR-17 implementation works (for example `php-http/guzzle7-adapter` if your app already uses Guzzle); see the [documentation](doc/readme.md) for alternatives.
+That's it. Auto-discovery wires the service provider and the `Swap` facade in Laravel 5.5+. Skip to [Quickstart](#-quickstart).
 
-Auto-discovery handles the rest in Laravel 5.5+. For Lumen and older Laravel versions, see [Setup](doc/readme.md#-setup) in the documentation.
+---
+
+_Optional: any PSR-18 HTTP client paired with a PSR-17 factory works. If your app already uses Guzzle, swap `symfony/http-client` for `php-http/guzzle7-adapter`. For Lumen or older Laravel versions, see [Setup](doc/readme.md#-setup) in the documentation._
 
 ## ⚡ Quickstart
+
+> **The `Swap` facade is available everywhere: controllers, jobs, console commands, queue workers, Blade templates. One static call returns a typed exchange rate.**
 
 Out of the box, the package works without an API key. Publish the config to customize providers and caching:
 
@@ -53,7 +63,7 @@ Out of the box, the package works without an API key. Publish the config to cust
 php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
 ```
 
-The published `config/swap.php` defaults to the European Central Bank (free, no key). You can now use the facade anywhere in the app:
+The published `config/swap.php` defaults to the European Central Bank (free, no key). Then call the facade anywhere in the app:
 
 ```php
 use Swap;

--- a/README.md
+++ b/README.md
@@ -1,138 +1,168 @@
-# <img src="https://s3.amazonaws.com/swap.assets/swap_logo.png" height="30px" width="30px"/> Laravel Swap
+# Laravel Swap
 
 [![Tests](https://github.com/florianv/laravel-swap/actions/workflows/tests.yml/badge.svg)](https://github.com/florianv/laravel-swap/actions/workflows/tests.yml)
 [![Psalm](https://github.com/florianv/laravel-swap/actions/workflows/psalm.yml/badge.svg)](https://github.com/florianv/laravel-swap/actions/workflows/psalm.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/florianv/laravel-swap.svg?style=flat-square)](https://packagist.org/packages/florianv/laravel-swap)
 [![Version](http://img.shields.io/packagist/v/florianv/laravel-swap.svg?style=flat-square)](https://packagist.org/packages/florianv/laravel-swap)
 
-Swap allows you to retrieve currency exchange rates from various services such as **[Fixer](https://fixer.io/)**, **[Currency Data](https://currencylayer.com)**
-or **[Exchange Rates Data](https://exchangeratesapi.io)** and optionally cache the results. 
+> _Drop-in currency conversion for Laravel and Lumen. Auto-discovered service provider, facade, and config. Maintained since 2014._
 
-## QuickStart
+Laravel Swap is a drop-in **Laravel currency conversion** package. Install it, get a facade, and start fetching exchange rates. Auto-discovery wires the service provider in Laravel 5.5+; configuration publishes to `config/swap.php`; rates are cached through the Laravel cache store you already have. Lumen is supported. Used in real-world Laravel applications since 2014.
 
-### Installation
+## 💡 What is Laravel Swap?
+
+- Laravel Swap is the Laravel application of [Swap](https://github.com/florianv/swap), the PHP currency conversion library.
+- It registers a service provider (`Swap\Laravel\SwapServiceProvider`) and a `Swap` facade.
+- Auto-discovery wires both in Laravel 5.5+ with no manual configuration.
+- Configuration is published to `config/swap.php`.
+- Rates are cached through any Laravel cache store you already have.
+- Lumen is supported with a few extra lines in `bootstrap/app.php`.
+
+## 🎯 When should you use Laravel Swap?
+
+- Use Laravel Swap when you need exchange rates inside a Laravel or Lumen application: localized prices, invoice totals, multi-currency reporting, historical FX data.
+- You do not need to install [Swap](https://github.com/florianv/swap) separately. It is pulled in as a dependency, and Laravel Swap exposes it through Laravel's service container, facade, and cache store.
+
+## 🧠 Why Laravel Swap and not raw Swap?
+
+- **Drop-in.** Auto-discovery in Laravel 5.5+. No manual provider or alias registration.
+- **Laravel cache integration.** Rates are cached through the cache store you already configured (`file`, `redis`, `database`, etc.), no PSR-16 wiring required.
+- **Facade.** `Swap::latest('EUR/USD')` from anywhere in the app.
+- **Config.** `config/swap.php` exposes providers, options, the cache store, the HTTP client, and the request factory.
+- **Lumen.** Supported with the same configuration shape.
+
+If you are not on Laravel or Lumen, use [Swap](https://github.com/florianv/swap) directly.
+
+## 📦 Installation
+
+Laravel Swap requires PHP 8.2 or newer.
 
 ```bash
-$ composer require php-http/curl-client nyholm/psr7 php-http/message florianv/laravel-swap
+composer require florianv/laravel-swap symfony/http-client nyholm/psr7
 ```
 
-### Laravel 5.7 or lesser
+`symfony/http-client` and `nyholm/psr7` provide the PSR-18 HTTP client and PSR-17 factories. Any PSR-18 / PSR-17 implementation works (for example `php-http/guzzle7-adapter` if your app already uses Guzzle); see the [documentation](doc/readme.md) for alternatives.
 
-If you use cache, add also PSR-6 adapter and PSR-16 bridge cache dependencies :
+Auto-discovery handles the rest in Laravel 5.5+. For Lumen and older Laravel versions, see [Setup](doc/readme.md#-setup) in the documentation.
+
+## ⚡ Quickstart
+
+Out of the box, the package works without an API key. Publish the config to customize providers and caching:
 
 ```bash
-$ composer require cache/illuminate-adapter cache/simple-cache-bridge
+php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
 ```
 
-These dependencies are not required with Laravel 5.8 or greater which [implements PSR-16](https://github.com/laravel/framework/pull/27217).
-
-### Laravel 5.5+
-
-If you don't use auto-discovery, add the `ServiceProvider` to the providers array in `config/app.php`:
+The published `config/swap.php` defaults to the European Central Bank (free, no key). You can now use the facade anywhere in the app:
 
 ```php
-// /config/app.php
-'providers' => [
-    Swap\Laravel\SwapServiceProvider::class
+use Swap;
+
+// EUR → USD exchange rate
+$rate = Swap::latest('EUR/USD');
+
+$rate->getValue();                 // e.g. 1.0823 (a float)
+$rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
+$rate->getProviderName();          // 'european_central_bank' by default
+
+// Convert an amount using the returned rate
+$amountInEUR = 100.00;
+$amountInUSD = $amountInEUR * $rate->getValue();
+
+// Historical rate
+$rate = Swap::historical('EUR/USD', \Carbon\Carbon::now()->subDays(15));
+```
+
+Add commercial providers in `config/swap.php`:
+
+```php
+// config/swap.php
+'services' => [
+    // Add a commercial provider with an API key, for example:
+    // 'apilayer_fixer'      => ['api_key' => env('SWAP_FIXER_KEY')],
+    // 'open_exchange_rates' => ['app_id'  => env('SWAP_OER_APP_ID')],
+
+    // Free fallback for EUR-base pairs:
+    'european_central_bank' => true,
 ],
 ```
 
-If you want to use the facade to log messages, add this to your facades in app.php:
+Providers are tried in order. If a provider does not support the requested currency pair, it is skipped silently. If a provider throws an error, the next provider is tried. If every provider fails, a `ChainException` is thrown with all collected errors.
 
-```
-'aliases' => [
-    'Swap' => Swap\Laravel\Facades\Swap::class
-]
-```
+## 💾 Caching
 
-Copy the package config to your local config with the publish command:
-
-```bash
-$ php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
-```
-
-### Lumen
-
-Configure the Service Provider and alias:
+Set `cache` in `config/swap.php` to any Laravel cache store name:
 
 ```php
-// /boostrap/app.php
-
-// Register the facade
-$app->withFacades(true, [
-    Swap\Laravel\Facades\Swap::class => 'Swap'
-]);
-
-// Load the configuration
-$app->configure('swap');
-
-// Register the service provider
-$app->register(Swap\Laravel\SwapServiceProvider::class);
+// config/swap.php
+'options' => [
+    'cache_ttl' => 3600,
+],
+'cache' => 'redis', // any Laravel cache store: file, redis, database, ...
 ```
 
-Copy the [configuration](config/swap.php) to `/config/swap.php` if you wish to override it.
-
-## Usage
+Per-query overrides:
 
 ```php
-// Get the latest EUR/USD rate
-$rate = Swap::latest('EUR/USD');
-
-// 1.129
-$rate->getValue();
-
-// 2016-08-26
-$rate->getDate()->format('Y-m-d');
-
-// Get the EUR/USD rate yesterday
-$rate = Swap::historical('EUR/USD', Carbon\Carbon::yesterday());
+Swap::latest('EUR/USD', ['cache' => false]);
+Swap::latest('EUR/USD', ['cache_ttl' => 60]);
 ```
 
-## Documentation
+See the [documentation](doc/readme.md#-caching) for the full reference, including cache key prefixes and PSR-6 limitations.
 
-The complete documentation can be found [here](https://github.com/florianv/laravel-swap/blob/master/doc/readme.md).
+## 🛠 Common use cases
 
-## Services
+- Display localized prices in multi-currency Laravel storefronts.
+- Compute invoice totals across currencies in a Laravel or Lumen API.
+- Reconcile multi-currency ledgers using historical rates.
+- Power internal FX dashboards with rate history.
+- Build currency conversion infrastructure for Laravel-based fintech and ERP applications.
 
-Here is the list of the currently implemented services:
+## 🧭 Which package should I use?
 
-| Service | Base Currency | Quote Currency | Historical |
-|---------------------------------------------------------------------------|----------------------|----------------|----------------|
-| [Fixer](https://fixer.io/) | EUR (free, no SSL), * (paid) | * | Yes |
-| [Currency Data](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [Exchange Rates Data](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [Abstract](https://www.abstractapi.com) | * | * | Yes |
-| [coinlayer](https://coinlayer.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies) | Yes |
-| [Fixer](https://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
-| [currencylayer](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [exchangeratesapi](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [European Central Bank](https://www.ecb.europa.eu/home/html/index.en.html) | EUR | * | Yes |
-| [National Bank of Georgia](https://nbg.gov.ge) | * | GEL | Yes |
-| [National Bank of the Republic of Belarus](https://www.nbrb.by) | * | BYN (from 01-07-2016),<br>BYR (01-01-2000 - 30-06-2016),<br>BYB (25-05-1992 - 31-12-1999) | Yes |
-| [National Bank of Romania](http://www.bnr.ro) | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | Yes |
-| [National Bank of Ukranie](https://bank.gov.ua) | * | UAH | Yes |
-| [Central Bank of the Republic of Turkey](http://www.tcmb.gov.tr) | * | TRY | Yes |
-| [Central Bank of the Republic of Uzbekistan](https://cbu.uz) | * | UZS | Yes |
-| [Central Bank of the Czech Republic](https://www.cnb.cz) | * | CZK | Yes |
-| [Central Bank of Russia](https://cbr.ru) | * | RUB | Yes |
-| [Bulgarian National Bank](http://bnb.bg) | * | BGN | Yes |
-| [WebserviceX](http://www.webservicex.net) | * | * | No |
-| [1Forge](https://1forge.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Cryptonator](https://www.cryptonator.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies)  | No |
-| [CurrencyDataFeed](https://currencydatafeed.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |
-| [Xignite](https://www.xignite.com) | * | * | Yes |
-| [Currency Converter API](https://www.currencyconverterapi.com) | * | * | Yes (free but limited or paid) |
-| [xChangeApi.com](https://xchangeapi.com) | * | * | Yes |
-| [fastFOREX.io](https://www.fastforex.io) | USD (free), * (paid) | * | No |
-| [exchangerate.host](https://www.exchangerate.host) | * | * | Yes |
-| Array | * | * | Yes |
+The Swap ecosystem is a layered toolkit for currency conversion in PHP:
 
-## Credits
+- **Swap.** The easy-to-use, high-level API for plain PHP.
+- **Exchanger.** Lower-level, more granular alternative; direct access to provider implementations.
+- **Laravel Swap.** Laravel application of Swap (this package).
+- **Symfony Swap.** Symfony integration of Swap.
 
-- [Florian Voutzinos](https://github.com/florianv)
-- [All Contributors](https://github.com/florianv/laravel-swap/contributors)
+All four packages are MIT-licensed and require PHP 8.2 or newer.
 
-## License
+## 📚 Documentation
+
+The full documentation, with the per-provider configuration reference, Lumen setup, custom service registration, and FAQ, is in [doc/readme.md](doc/readme.md). The full provider list with capabilities is in the [Swap README](https://github.com/florianv/swap#-providers).
+
+## 🧩 Related packages
+
+The Swap ecosystem:
+
+- [**Swap**](https://github.com/florianv/swap): easy-to-use PHP currency conversion library.
+- [**Exchanger**](https://github.com/florianv/exchanger): exchange rate provider layer.
+- [**Laravel Swap**](https://github.com/florianv/laravel-swap): Laravel application of Swap (this package).
+- [**Symfony Swap**](https://github.com/florianv/symfony-swap): Symfony integration of Swap.
+
+## 🤝 Sponsorship
+
+The Swap ecosystem is open to selected sponsorships from exchange rate API providers and financial infrastructure companies.
+
+Sponsorship can include:
+
+- Documentation visibility
+- Integration examples
+- Ecosystem-level visibility across Swap, Exchanger, Laravel Swap, and Symfony Swap
+
+For inquiries, contact the maintainer via [GitHub](https://github.com/florianv).
+
+## 🙌 Contributing
+
+Issues and pull requests are welcome. Please see the existing [issues](https://github.com/florianv/laravel-swap/issues) before opening a new one.
+
+## 📄 License
 
 The MIT License (MIT). Please see [LICENSE](https://github.com/florianv/laravel-swap/blob/master/LICENSE) for more information.
+
+## 👏 Credits
+
+- [Florian Voutzinos](https://github.com/florianv)
+- [All contributors](https://github.com/florianv/laravel-swap/contributors)

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,16 @@
 {
     "name": "florianv/laravel-swap",
     "type": "library",
-    "description": "Currency exchange rates library for Laravel and Lumen",
+    "description": "Drop-in Laravel currency conversion: auto-discovered service provider, facade, and config. Multi-provider exchange rates.",
     "keywords": [
+        "php",
         "laravel",
         "lumen",
-        "currency",
-        "money",
-        "rate",
-        "conversion",
-        "exchange rates"
+        "currency-conversion",
+        "exchange-rates",
+        "exchange-rate-api",
+        "swap",
+        "money"
     ],
     "homepage": "https://github.com/florianv/laravel-swap",
     "license": "MIT",

--- a/config/swap.php
+++ b/config/swap.php
@@ -86,9 +86,12 @@ return [
     |
     */
     'services' => [
-        'apilayer_fixer' => ['api_key' => 'Get your key here: https://fixer.io/'],
-        'apilayer_currency_data' => ['api_key' => 'Get your key here: https://currencylayer.com'],
-        'apilayer_exchange_rates_data' => ['api_key' => 'Get your key here: https://exchangeratesapi.io'],
+        // The European Central Bank is free and works without an API key.
+        // Add commercial providers above this line, for example:
+        // 'apilayer_fixer'      => ['api_key' => env('SWAP_FIXER_KEY')],
+        // 'open_exchange_rates' => ['app_id'  => env('SWAP_OER_APP_ID')],
+
+        'european_central_bank' => true,
     ],
 
     /*

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,98 +1,102 @@
 # Documentation
 
-## Sponsors
+## 💡 What is Laravel Swap?
 
-<table>
-   <tr>
-      <td><img src="https://assets.apilayer.com/apis/fixer.png" width="50px"/></td>
-      <td><a href="https://fixer.io/">Fixer</a> is a simple and lightweight API for foreign exchange rates that supports up to 170 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/currency_data.png" width="50px"/></td>
-     <td><a href="https://currencylayer.com">Currency Data</a> provides reliable exchange rates and currency conversions for your business up to 168 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/exchangerates_data.png" width="50px"/></td>
-     <td><a href="https://exchangeratesapi.io">Exchange Rates Data</a> provides reliable exchange rates and currency conversions for your business with over 15 data sources.</td>
-   </tr> 
-</table>
+- Laravel Swap is the Laravel application of [Swap](https://github.com/florianv/swap), the PHP currency conversion library.
+- It registers a service provider (`Swap\Laravel\SwapServiceProvider`) and a `Swap` facade.
+- Auto-discovery wires both in Laravel 5.5+ with no manual configuration.
+- Configuration publishes to `config/swap.php`.
+- Rates are cached through any Laravel cache store you already have.
+- Lumen is supported with a few extra lines in `bootstrap/app.php`.
+
+For the wider ecosystem (Swap, Exchanger, Symfony Swap), see the [README](../README.md).
+
+## 🎯 When should you use Laravel Swap?
+
+- Use Laravel Swap when you need exchange rates inside a Laravel or Lumen application: localized prices, invoice totals, multi-currency reporting, historical FX data.
+- You do not need to install [Swap](https://github.com/florianv/swap) separately. It is pulled in as a dependency, and Laravel Swap exposes it through Laravel's service container, facade, and cache store.
+
+## 🧠 Why Laravel Swap and not raw Swap?
+
+- **Drop-in.** Auto-discovery in Laravel 5.5+. No manual provider or alias registration.
+- **Laravel cache.** Rates are cached through the cache store you already configured (`file`, `redis`, `database`, etc.), no PSR-16 wiring required.
+- **Facade.** `Swap::latest('EUR/USD')` from anywhere in the app.
+- **Config.** `config/swap.php` exposes providers, options, the cache store, the HTTP client, and the request factory.
+- **Lumen.** Supported with the same configuration shape.
 
 ## Index
 
-* [Installation](#installation)
-* [Setup](#setup)
+* [Installation](#-installation)
+* [Setup](#-setup)
   * [Laravel](#laravel)
   * [Lumen](#lumen)
-* [Configuration](#configuration)
-* [Usage](#usage)
-  * [Retrieving Rates](#retrieving-rates)
-  * [Rate Provider](#rate-provider)
-* [Cache](#cache)
-  * [Rates Caching](#rates-caching)
-  * [Query Cache Options](#cache-options)
-* [Creating a Service](#creating-a-service)
-  * [Standard Service](#standard-service)
-  * [Historical Service](#historical-service)
-* [Supported Services](#supported-services)  
+* [Configuration](#-configuration)
+  * [Publishing the config](#publishing-the-config)
+  * [Provider configuration](#provider-configuration)
+  * [Selecting the HTTP client](#selecting-the-http-client)
+* [Usage](#-usage)
+  * [The facade](#the-facade)
+  * [Latest and historical rates](#latest-and-historical-rates)
+  * [Inspecting the rate](#inspecting-the-rate)
+* [Caching](#-caching)
+  * [Using the Laravel cache](#using-the-laravel-cache)
+  * [Per-query options](#per-query-options)
+* [Creating a custom service](#-creating-a-custom-service)
+  * [Standard service](#standard-service)
+  * [Historical service](#historical-service)
+* [FAQ](#-faq)
 
-## Installation
+## 📦 Installation
 
-Swap is decoupled from any library sending HTTP requests (like Guzzle), instead it uses an abstraction called [HTTPlug](http://httplug.io/) 
-which provides the http layer used to send requests to exchange rate services. 
-
-Below is an example using Curl:
+Laravel Swap requires PHP 8.2 or newer.
 
 ```bash
-$ composer require php-http/curl-client nyholm/psr7 php-http/message florianv/laravel-swap
+composer require florianv/laravel-swap symfony/http-client nyholm/psr7
 ```
 
-## Setup
+`symfony/http-client` is the PSR-18 HTTP client and `nyholm/psr7` provides the PSR-17 factories. Any PSR-18 / PSR-17 implementation works; for example, if your app already uses Guzzle:
+
+```bash
+composer require florianv/laravel-swap php-http/guzzle7-adapter nyholm/psr7
+```
+
+## ⚙ Setup
 
 ### Laravel
 
-If you don't use auto-discovery, add the ServiceProvider to the providers array in config/app.php
+Auto-discovery in Laravel 5.5+ wires the service provider and the `Swap` facade automatically. Nothing more to do for setup.
+
+If auto-discovery is disabled, register them manually in `config/app.php`:
 
 ```php
-// /config/app.php
+// config/app.php
 'providers' => [
-    Swap\Laravel\SwapServiceProvider::class
+    Swap\Laravel\SwapServiceProvider::class,
+],
+
+'aliases' => [
+    'Swap' => Swap\Laravel\Facades\Swap::class,
 ],
 ```
 
-If you want to use the facade to log messages, add this to your facades in app.php:
-
-```
-'aliases' => [
-    'Swap' => Swap\Laravel\Facades\Swap::class
-]
-```
-
-Copy the package config to your local config with the publish command:
+**Laravel 5.7 or older.** If you use the cache, also install the PSR-6 / PSR-16 bridges:
 
 ```bash
-$ php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
+composer require cache/illuminate-adapter cache/simple-cache-bridge
 ```
 
-__Laravel 5.7 or lesser :__
-
-If you use cache, add also PSR-6 adapter and PSR-16 bridge cache dependencies :
-
-```bash
-$ composer require cache/illuminate-adapter cache/simple-cache-bridge
-```
-
-These dependencies are not required with Laravel 5.8 or greater which [implements PSR-16](https://github.com/laravel/framework/pull/27217).
+These dependencies are not required on Laravel 5.8+, which [implements PSR-16 natively](https://github.com/laravel/framework/pull/27217).
 
 ### Lumen
 
-Configure the Service Provider and alias:
+In `bootstrap/app.php`:
 
 ```php
-// /boostrap/app.php
+// bootstrap/app.php
 
 // Register the facade
 $app->withFacades(true, [
-    Swap\Laravel\Facades\Swap::class => 'Swap'
+    Swap\Laravel\Facades\Swap::class => 'Swap',
 ]);
 
 // Load the configuration
@@ -102,125 +106,164 @@ $app->configure('swap');
 $app->register(Swap\Laravel\SwapServiceProvider::class);
 ```
 
-Copy the [configuration](config/swap.php) to `/config/swap.php` if you wish to override it.
+Copy [the package config](../config/swap.php) to `config/swap.php` to override defaults.
 
-## Configuration
+## ⚙ Configuration
 
-By default Swap uses the [Fixer](https://fixer.io/) service, and will fallback to [Currency Data](https://currencylayer.com) in case of failure.
+### Publishing the config
 
-If you wish to use different services, you can modify the `services` configuration:
-
-```php
-// app/config/swap.php
-'services' => [
-  'apilayer_fixer' => ['api_key' => 'Get your key here: https://fixer.io/'],
-  'apilayer_currency_data' => ['api_key' => 'Get your key here: https://currencylayer.com'],
-  'apilayer_exchange_rates_data' => ['api_key' => 'Get your key here: https://exchangeratesapi.io'],
-]    
+```bash
+php artisan vendor:publish --provider="Swap\Laravel\SwapServiceProvider"
 ```
 
-We recommend to use one of the [services that support our project](#sponsors), providing a free plan up to 100 requests per month.
+This creates `config/swap.php` in your application. The default config wires the European Central Bank (free, no API key) so the package works out of the box.
 
-The complete list of all supported services is available [here](#supported-services).
+### Provider configuration
 
-## Usage
-
-### Retrieving Rates
-
-In order to get rates, you can use the `latest()` or `historical()` methods on `Swap`:
+Public providers (central banks, national banks, `cryptonator`, `exchangeratehost`, `webservicex`) need no configuration. Use `true` as the value:
 
 ```php
-// Get the latest EUR/USD rate
+// config/swap.php
+'services' => [
+    'european_central_bank'   => true,
+    'national_bank_of_romania' => true,
+],
+```
+
+Commercial providers require an API key. The option name varies by provider:
+
+| Identifier                       | Required option | Optional flags        |
+| -------------------------------- | --------------- | --------------------- |
+| `abstract_api`                   | `api_key`       |                       |
+| `apilayer_currency_data`         | `api_key`       |                       |
+| `apilayer_exchange_rates_data`   | `api_key`       |                       |
+| `apilayer_fixer`                 | `api_key`       |                       |
+| `coin_layer`                     | `access_key`    | `paid` (bool)         |
+| `currency_converter`             | `access_key`    | `enterprise` (bool)   |
+| `currency_data_feed`             | `api_key`       |                       |
+| `currency_layer`                 | `access_key`    | `enterprise` (bool)   |
+| `exchange_rates_api`             | `access_key`    |                       |
+| `fastforex`                      | `api_key`       |                       |
+| `fixer`                          | `access_key`    |                       |
+| `fixer_apilayer`                 | `api_key`       |                       |
+| `forge`                          | `api_key`       |                       |
+| `open_exchange_rates`            | `app_id`        | `enterprise` (bool)   |
+| `xchangeapi`                     | `api-key`       | (note the hyphen)     |
+| `xignite`                        | `token`         |                       |
+
+Example:
+
+```php
+// config/swap.php
+'services' => [
+    'apilayer_fixer'      => ['api_key' => env('SWAP_FIXER_KEY')],
+    'open_exchange_rates' => ['app_id'  => env('SWAP_OER_APP_ID'), 'enterprise' => false],
+    'european_central_bank' => true, // free fallback
+],
+```
+
+Providers are tried in order. See [How the fallback chain works](https://github.com/florianv/swap#-configuring-multiple-providers-fallback-chain) in the Swap README for the full semantics.
+
+The full provider list with capabilities (base currency, quote currency, historical support) is in the [Swap README's Providers table](https://github.com/florianv/swap#-providers).
+
+### Selecting the HTTP client
+
+By default, Swap auto-discovers a PSR-18 client via `php-http/discovery`. To pass a specific client from the Laravel container, set the `http_client` config key to a service name registered in your container:
+
+```php
+// config/swap.php
+'http_client' => 'my_http_client',     // a service ID in the Laravel container
+'request_factory' => 'my_psr17_factory', // optional PSR-17 factory service ID
+```
+
+## ⚡ Usage
+
+### The facade
+
+`Swap::` resolves to `Swap\Swap` from the container. The facade exposes the same two methods:
+
+```php
+public static function latest(string $currencyPair, array $options = []): \Exchanger\Contract\ExchangeRate;
+public static function historical(string $currencyPair, \DateTimeInterface $date, array $options = []): \Exchanger\Contract\ExchangeRate;
+```
+
+You can also resolve it manually:
+
+```php
+$swap = app('swap');                       // \Swap\Swap
+$swap = app(\Swap\Swap::class);            // same instance
+```
+
+### Latest and historical rates
+
+```php
+use Swap;
+
 $rate = Swap::latest('EUR/USD');
 
-// 1.129
-$rate->getValue();
+echo $rate->getValue();                 // e.g. 1.0823
+echo $rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
 
-// 2016-08-26
-$rate->getDate()->format('Y-m-d');
-
-// Get the EUR/USD rate yesterday
-$rate = Swap::historical('EUR/USD', Carbon\Carbon::yesterday());
+$rate = Swap::historical('EUR/USD', \Carbon\Carbon::now()->subDays(15));
 ```
 
-### Rate provider
+> Currencies are expressed as their [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code.
 
-When using the chain service, it can be useful to know which service provided the rate.
+### Inspecting the rate
 
-You can use the `getProviderName()` function on a rate that gives you the name of the service that returned it:
+The returned `Exchanger\Contract\ExchangeRate` exposes:
 
 ```php
-$name = $rate->getProviderName();
+$rate->getValue();         // float
+$rate->getDate();          // DateTimeInterface
+$rate->getCurrencyPair();  // Exchanger\CurrencyPair
+$rate->getProviderName();  // string, the identifier that returned the rate
 ```
 
-For example, if Fixer returned the rate, it will be identical to `fixer`.
+`getProviderName()` is useful when several providers are configured: the returned value is the identifier of the provider that actually answered, for example `european_central_bank`.
 
-## Cache
+## 💾 Caching
 
-### Rates Caching
+### Using the Laravel cache
 
-It is possible to cache rates during a given time using the Laravel cache store of your choice.
+Set `cache` in `config/swap.php` to any Laravel cache store name:
 
 ```php
-// app/config/swap.php
-[
-    'options' => [
-        'cache_ttl' => 3600
-    ],
-    
-    'cache' => 'file'
-]
+// config/swap.php
+'options' => [
+    'cache_ttl'        => 3600,
+    'cache_key_prefix' => 'myapp-',
+],
+'cache' => 'redis', // any Laravel cache store: file, redis, database, ...
 ```
 
-Rates are now cached using the Laravel `file` store during 3600 seconds.
+On Laravel 5.8+ the store is used directly. On Laravel 5.7 or older, the package uses the PSR-6 / PSR-16 bridges installed during [Setup](#-setup).
 
-### Query Cache Options
+### Per-query options
 
-You can override `Swap` caching options per request.
+Cache behavior can be overridden per call by passing an options array to `latest()` or `historical()`.
 
-#### cache_ttl
+| Option             | Type   | Default | Effect                                                                                                |
+| ------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
+| `cache_ttl`        | int    | `null`  | Cache TTL in seconds. `null` means entries do not expire.                                             |
+| `cache`            | bool   | `true`  | Set to `false` to bypass the cache for this call.                                                     |
+| `cache_key_prefix` | string | `""`    | Prefix for the cache key. Max 24 characters (PSR-6 limits keys to 64 chars; the internal hash takes 40). |
 
-Set cache TTL in seconds. Default: `null` - cache entries permanently
+PSR-6 does not allow the characters `{}()/\@:` in keys; Swap replaces them with `-`.
 
 ```php
-// Override the global cache_ttl only for this query
-$rate = Swap::latest('EUR/USD', ['cache_ttl' => 60]);
-$rate = Swap::historical('EUR/USD', $date, ['cache_ttl' => 60]);
+Swap::latest('EUR/USD', ['cache' => false]);
+Swap::latest('EUR/USD', ['cache_ttl' => 60]);
+Swap::latest('EUR/USD', ['cache_key_prefix' => 'currencies-special-']);
 ```
 
-#### cache
+## 🧩 Creating a custom service
 
-Disable/Enable caching. Default: `true`
-
-```php
-// Disable caching for this query
-$rate = Swap::latest('EUR/USD', ['cache' => false]);
-$rate = Swap::historical('EUR/USD', $date, ['cache' => false]);
-```
-
-#### cache_key_prefix
-
-Set the cache key prefix. Default: empty string
-
-There is a limitation of 64 characters for the key length in PSR-6, because of this, key prefix must not exceed 24 characters, as sha1() hash takes 40 symbols.
-
-PSR-6 do not allows characters `{}()/\@:` in key, these characters are replaced with `-`
-
-```php
-// Override cache key prefix for this query
-$rate = Swap::latest('EUR/USD', ['cache_key_prefix' => 'currencies-special-']);
-$rate = Swap::historical('EUR/USD', $date, ['cache_key_prefix' => 'currencies-special-']);
-```
-
-## Creating a Service
-
-You want to add a new service to `Swap` ? Great!
-
-If your service must send http requests to retrieve rates, your class must extend the `HttpService` class, otherwise you can extend the more generic `Service` class.
+You can register your own provider by implementing the same contract used internally. If your service makes HTTP requests, extend `Exchanger\Service\HttpService`; otherwise extend `Exchanger\Service\Service`.
 
 ### Standard service
 
-In the following example, we are creating a `Constant` service that returns a constant rate value.
+Create the service class:
 
 ```php
 namespace App\Swap;
@@ -231,28 +274,14 @@ use Exchanger\Service\HttpService;
 
 class ConstantService extends HttpService
 {
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     public function getExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
-        // If you want to make a request you can use
-        // $content = $this->request('http://example.com');
+        // To call an HTTP endpoint:
+        // $content = $this->request('https://example.com');
 
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Processes the service options.
-     *
-     * @param array &$options
-     *
-     * @return void
-     */
     public function processOptions(array &$options): void
     {
         if (!isset($options['value'])) {
@@ -260,24 +289,11 @@ class ConstantService extends HttpService
         }
     }
 
-    /**
-     * Tells if the service supports the exchange rate query.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return bool
-     */
     public function supportQuery(ExchangeRateQuery $exchangeQuery): bool
     {
-        // For example, our service only supports EUR as base currency
         return 'EUR' === $exchangeQuery->getCurrencyPair()->getBaseCurrency();
     }
 
-    /**
-     * Gets the name of the exchange rate service.
-     *
-     * @return string
-     */
     public function getName(): string
     {
         return 'constant';
@@ -285,32 +301,26 @@ class ConstantService extends HttpService
 }
 ```
 
-You will need to register it in the `boot()` method of your `AppServiceProvider`:
+Register it in your `AppServiceProvider`:
 
 ```php
-// /app/Providers/AppServiceProvider.php
+// app/Providers/AppServiceProvider.php
 use Swap\Service\Registry;
 use App\Swap\ConstantService;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
+    public function boot(): void
     {
         Registry::register('constant', ConstantService::class);
     }
 }
 ```
 
-Then you can use it in the config:
+Then use the identifier in `config/swap.php`:
 
 ```php
-// /config/swap.php
-
+// config/swap.php
 'services' => [
     'constant' => ['value' => 10],
 ],
@@ -318,84 +328,57 @@ Then you can use it in the config:
 
 ### Historical service
 
-If your service supports retrieving historical rates, you need to use the `SupportsHistoricalQueries` trait.
-
-You will need to rename the `getExchangeRate` method to `getLatestExchangeRate` and switch its visibility to protected, and implement a new `getHistoricalExchangeRate` method:
+To support historical rates, use the `SupportsHistoricalQueries` trait. Rename `getExchangeRate` to `getLatestExchangeRate` (now `protected`) and implement `getHistoricalExchangeRate`:
 
 ```php
+use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\ExchangeRate;
+use Exchanger\HistoricalExchangeRateQuery;
+use Exchanger\Service\HttpService;
 use Exchanger\Service\SupportsHistoricalQueries;
 
 class ConstantService extends HttpService
 {
     use SupportsHistoricalQueries;
-    
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
+
     protected function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Gets an historical rate.
-     *
-     * @param HistoricalExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
-}    
+}
 ```
-    
-### Supported Services
 
-Here is the complete list of supported services and their possible configurations:
+## ❓ FAQ
 
-```php
-// app/config/swap.php
-'services' => [
-    'apilayer_fixer' => ['api_key' => 'Get your key here: https://fixer.io/'],
-    'apilayer_currency_data' => ['api_key' => 'Get your key here: https://currencylayer.com'],
-    'apilayer_exchange_rates_data' => ['api_key' => 'Get your key here: https://exchangeratesapi.io'],
-    'abstract_api' => ['api_key' => 'Get your key here: https://app.abstractapi.com/users/signup'],
-    'fixer' => ['access_key' => 'YOUR_KEY'],
-    'currency_layer' => ['access_key' => 'secret', 'enterprise' => false],
-    'exchange_rates_api' => ['access_key' => 'secret'],
-    'coin_layer' => ['access_key' => 'secret', 'paid' => false],
-    'european_central_bank' => true,
-    'national_bank_of_romania' => true,
-    'central_bank_of_republic_turkey' => true,
-    'central_bank_of_czech_republic' => true,
-    'russian_central_bank' => true,
-    'bulgarian_national_bank' => true,
-    'webservicex' => true,
-    'forge' => ['api_key' => 'secret'],
-    'cryptonator' => true,
-    'currency_data_feed' => ['api_key' => 'secret'],
-    'open_exchange_rates' => ['app_id' => 'secret', 'enterprise' => false],
-    'xignite' => ['token' => 'token'],
-    'xchangeapi' => ['api-key' => 'api-key'],
-    'array' => [
-        [
-            'EUR/USD' => 1.1,
-            'EUR/GBP' => 1.5
-        ],
-        [
-            '2017-01-01' => [
-                'EUR/USD' => 1.5
-            ],
-            '2017-01-03' => [
-                'EUR/GBP' => 1.3
-            ],
-        ]
-    ],
-]
-```            
+#### What happens when every provider fails?
+
+Swap throws an `Exchanger\Exception\ChainException`. Calling `$exception->getExceptions()` on it returns the list of exceptions collected from each provider in the chain.
+
+#### Can I use Laravel Swap without an API key?
+
+Yes. The published config defaults to the European Central Bank, which is free. The national banks, `cryptonator`, `exchangeratehost`, and `webservicex` also work without a key. See the [Swap README's Providers table](https://github.com/florianv/swap#-providers) for the full list.
+
+#### How does Laravel Swap relate to Swap?
+
+Laravel Swap is the Laravel application of Swap. It pulls Swap in as a dependency and exposes it through Laravel's service container, facade, and cache store. If you are not on Laravel or Lumen, use [Swap](https://github.com/florianv/swap) directly.
+
+#### How do I cache rates?
+
+Set `cache` in `config/swap.php` to any Laravel cache store name (for example `redis`, `file`, `database`). See [Caching](#-caching).
+
+#### How do I disable cache for a single query?
+
+Pass `['cache' => false]` as the options argument: `Swap::latest('EUR/USD', ['cache' => false])`.
+
+#### How do I add my own provider?
+
+Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), register it from your `AppServiceProvider` with `Swap\Service\Registry::register()`, then reference its identifier in `config/swap.php`. See [Creating a custom service](#-creating-a-custom-service).
+
+#### Where is the full provider list with capabilities?
+
+In the [Swap README's Providers table](https://github.com/florianv/swap#-providers). It lists every supported identifier with its base currency, quote currency, and historical support.


### PR DESCRIPTION
## What changed

### README

- Rewrote around a 'plug-and-play Laravel' value proposition: drop-in currency conversion, auto-discovered service provider, facade, and config, with the Laravel cache store wired automatically.
- New orientation sections (*What is Laravel Swap?*, *When should you use Laravel Swap?*, *Why Laravel Swap and not raw Swap?*, *Common use cases*, *Which package should I use?*), aligned with the Swap README.
- The facade usage is shown immediately (``Swap::latest('EUR/USD')``). The package works out of the box without an API key thanks to the European Central Bank default in the published config.
- Moved the Laravel 5.7-or-older PSR-6 / PSR-16 bridge detour out of the README and into the documentation, where it belongs.
- Dropped the legacy Services table that duplicated the Swap README. The Laravel Swap README now points to the canonical Swap [Providers table](https://github.com/florianv/swap#-providers).
- Added cross-links to Swap, Exchanger, and Symfony Swap.
- Added a neutral Sponsorship section near the bottom.
- Added light section emojis for visual scanning.

### `doc/readme.md`

- Dropped the legacy `## Sponsors` block at the top and the *'we recommend the services that support our project'* line in `## Configuration`. No commercial provider is preferred.
- Added the same orientation sections at the top so the doc stands on its own and aligns vocabulary with the README.
- Modernized Installation (PSR-18 first via `symfony/http-client`, Guzzle 7 alternative noted; the HTTPlug-first framing is removed).
- Restructured Setup into Laravel and Lumen subsections; the Laravel 5.7 bridges note is now a small inline aside, not a top-of-page detour.
- Added a *Provider configuration* table mapping each commercial identifier to its required option (`api_key`, `access_key`, `app_id`, `token`, `api-key`) and optional flags (`enterprise`, `paid`). Public providers and the ``array`` fixture are documented separately.
- Added a *Selecting the HTTP client* subsection covering the ``http_client`` / ``request_factory`` config keys.
- Compacted the *Per-query options* section into a single options table plus example block.
- Replaced the legacy *Supported Services* code dump with a pointer to the [Swap README Providers table](https://github.com/florianv/swap#-providers), which is the canonical list.
- Added a short FAQ at the end.

### `config/swap.php`

- Neutralized the default `services` list. The published config now ships the European Central Bank as the default provider (free, no API key) so the package works end-to-end on a fresh ``vendor:publish``. Commercial providers are documented as commented examples above. (The previous values were never functional API keys, so this is not a behavior change for any real install.)

### `composer.json`

- Updated description and Packagist keywords for discoverability.

## Why

- A new Laravel developer running ``composer require florianv/laravel-swap`` and ``vendor:publish`` immediately gets a working ``Swap::latest('EUR/USD')`` call, with no commercial-API friction.
- High-intent terms (Laravel currency conversion, exchange rates, drop-in, service provider, facade) are now in headings, the opening paragraph, and the Packagist metadata.
- The README is a value-proposition page, not a duplicate of the Swap README. The Providers table lives in one place.

## What did NOT change

- No runtime code changes. Public API of ``Swap\\Laravel\\SwapServiceProvider`` and ``Swap\\Laravel\\Facades\\Swap`` is unchanged.
- No changes to ``src/``, ``tests/``, CI, Psalm config, or php-cs-fixer config.
- The CHANGELOG was not touched (this is doc work, not a release).