### PR TITLE
docs: list unirate_api in config/swap.php + provider tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See the [documentation](doc/readme.md#-caching) for the full reference, includin
 
 ## 📊 Providers
 
-Laravel Swap supports the 30 exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `services` in `config/swap.php`.
+Laravel Swap supports the 31 exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `services` in `config/swap.php`.
 
 ### Commercial providers (require an API key)
 
@@ -126,6 +126,7 @@ Laravel Swap supports the 30 exchange rate providers from the underlying [Swap](
 | Fixer (direct)                           | `fixer`                        | EUR (free), * (paid) | *     | Yes        |
 | 1Forge                                   | `forge`                        | *                    | *     | No         |
 | Open Exchange Rates                      | `open_exchange_rates`          | USD (free), * (paid) | *     | Yes        |
+| UniRateAPI                               | `unirate_api`                  | *                    | *     | Yes        |
 | WebserviceX                              | `webservicex`                  | *                    | *     | No         |
 | xChangeApi.com                           | `xchangeapi`                   | *                    | *     | Yes        |
 | Xignite                                  | `xignite`                      | *                    | *     | Yes        |

--- a/config/swap.php
+++ b/config/swap.php
@@ -86,6 +86,10 @@ return [
     | * 'xchangeapi' => [
     |       'api-key' => 'secret', // The API token
     |   ]
+    |
+    | * 'unirate_api' => [
+    |       'api_key' => 'secret', // The API token. Get a free one at https://unirateapi.com
+    |   ]
 
     |
     */
@@ -100,6 +104,7 @@ return [
         // Other commercial providers — uncomment and configure the ones you want:
         // 'apilayer_fixer'      => ['api_key' => env('SWAP_FIXER_KEY')],
         // 'open_exchange_rates' => ['app_id'  => env('SWAP_OER_APP_ID')],
+        // 'unirate_api'         => ['api_key' => env('SWAP_UNIRATE_API_KEY')],
 
         // Free fallback for EUR-base pairs. Works out of the box without any key.
         'european_central_bank' => true,

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -141,6 +141,7 @@ Commercial providers require an API key. The option name varies by provider. The
 | `fixer_apilayer`                 | `api_key`       |                       |
 | `forge`                          | `api_key`       |                       |
 | `open_exchange_rates`            | `app_id`        | `enterprise` (bool)   |
+| `unirate_api`                    | `api_key`       |                       |
 | `xchangeapi`                     | `api-key`       | (note the hyphen)     |
 | `xignite`                        | `token`         |                       |
 


### PR DESCRIPTION
Adds [UniRateAPI](https://unirateapi.com/) to the Laravel-Swap config stub and the documented provider lists, following the merged work upstream:

- [florianv/exchanger#180](https://github.com/florianv/exchanger/pull/180) — landed the `UniRateApi` service and registered it under the identifier `unirate_api`.
- [florianv/swap#155](https://github.com/florianv/swap/pull/155) — docs PR for the high-level package (this PR's sibling).

`SwapServiceProvider` builds the chain by iterating the `services` array in `config/swap.php` and forwarding each entry to `Swap\Builder::add($identifier, $options)`, which delegates to `Exchanger\Service\Registry`. Once the next Exchanger release tag publishes, Laravel-Swap users can drop in:

```php
// config/swap.php
'services' => [
    'unirate_api' => ['api_key' => env('SWAP_UNIRATE_API_KEY')],
    // ...
],
```

…with no further wiring. This PR only updates the published config and the docs.

### Changes

- **config/swap.php**
  - Adds `unirate_api` to the in-file docblock spec list (after `xchangeapi`), matching the existing `fastforex` / `apilayer_fixer` / `forge` blocks.
  - Adds a commented-out `'unirate_api' => ['api_key' => env('SWAP_UNIRATE_API_KEY')]` line next to the other commercial-provider examples in `services`.
- **README.md** — adds `UniRateAPI` row to the commercial provider table (alphabetical, between `open_exchange_rates` and `webservicex`); bumps the count `30 → 31`.
- **doc/readme.md** — adds `unirate_api` / `api_key` row to the commercial configuration table.

### Notes

- Identifier `unirate_api` matches the key in `Exchanger\Service\Registry::getServices()` after #180; Laravel-Swap doesn't need any code change to pick it up.
- UniRateAPI is a commercial REST API for FX (170+ currencies, EUR/USD/any base). Latest rates are on the free tier; historical (`/api/historical`) and commodities are paid-tier only — the upstream `UniRateApi.php` maps HTTP 403 on those endpoints to `Exchanger\Exception\ChainException`, matching the existing fastFOREX / Fixer plan-gated behaviour, so the chain falls through cleanly.

### Disclosure

I work with UniRateAPI. The implementation work (Exchanger #180) was done first; opening this docs + config-stub PR now that the upstream merge has landed so Laravel users discover the provider through the standard publish flow instead of having to read the changelog. Happy to revise the wording, drop the count bump until the next Exchanger release tag, or split the README/doc changes off from `config/swap.php` if you'd rather review them separately.
