### PR TITLE
docs: express provider count as 30+

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See the [documentation](doc/readme.md#-caching) for the full reference, includin
 
 ## 📊 Providers
 
-Laravel Swap supports the 31 exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `services` in `config/swap.php`.
+Laravel Swap supports the 30+ exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `services` in `config/swap.php`.
 
 ### Commercial providers (require an API key)
 


### PR DESCRIPTION
Words the provider count as `30+` instead of a hardcoded exact number, so it stays correct as the underlying Swap provider list grows (no recurring docs edit).

### Changes

- **README.md** — provider configuration section now reads `30+` instead of `31`.

Docs only.