### PR TITLE
Use psalm/plugin-laravel v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "graham-campbell/testbench": "^6.2",
         "phpunit/phpunit": "^11.0 || ^12.0",
-        "vimeo/psalm": "^6.0",
+        "psalm/plugin-laravel": "^4.13",
         "roave/backward-compatibility-check": "^8.9",
         "php-http/guzzle7-adapter": "^1.0",
         "nyholm/psr7": "^1.0"
@@ -65,5 +65,7 @@
                 "Swap": "Swap\\Laravel\\Facades\\Swap"
             }
         }
-    }
+    },
+    "minimum-stability": "beta",
+    "prefer-stable": true
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,9 +4,6 @@
     <MissingOverrideAttribute>
       <code><![CDATA[protected static function getFacadeAccessor()]]></code>
     </MissingOverrideAttribute>
-    <MissingPureAnnotation>
-      <code><![CDATA[getFacadeAccessor]]></code>
-    </MissingPureAnnotation>
     <UnusedClass>
       <code><![CDATA[Swap]]></code>
     </UnusedClass>
@@ -28,9 +25,6 @@
       <code><![CDATA[public function provides()]]></code>
       <code><![CDATA[public function register()]]></code>
     </MissingOverrideAttribute>
-    <MissingPureAnnotation>
-      <code><![CDATA[provides]]></code>
-    </MissingPureAnnotation>
     <MissingReturnType>
       <code><![CDATA[boot]]></code>
     </MissingReturnType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
   <file src="src/Facades/Swap.php">
     <MissingOverrideAttribute>
       <code><![CDATA[protected static function getFacadeAccessor()]]></code>
     </MissingOverrideAttribute>
+    <MissingPureAnnotation>
+      <code><![CDATA[getFacadeAccessor]]></code>
+    </MissingPureAnnotation>
     <UnusedClass>
       <code><![CDATA[Swap]]></code>
     </UnusedClass>
@@ -25,12 +28,18 @@
       <code><![CDATA[public function provides()]]></code>
       <code><![CDATA[public function register()]]></code>
     </MissingOverrideAttribute>
+    <MissingPureAnnotation>
+      <code><![CDATA[provides]]></code>
+    </MissingPureAnnotation>
     <MissingReturnType>
       <code><![CDATA[boot]]></code>
     </MissingReturnType>
     <MixedArgument>
       <code><![CDATA[$app->config->get('swap.options', [])]]></code>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$httpClient]]></code>
       <code><![CDATA[$name]]></code>
+      <code><![CDATA[$requestFactory]]></code>
     </MixedArgument>
     <MixedArrayOffset>
       <code><![CDATA[$this->app[$httpClient]]]></code>
@@ -42,7 +51,6 @@
       <code><![CDATA[$httpClient]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$requestFactory]]></code>
-      <code><![CDATA[$store]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[get]]></code>
@@ -51,7 +59,6 @@
       <code><![CDATA[get]]></code>
       <code><![CDATA[get]]></code>
       <code><![CDATA[getStore]]></code>
-      <code><![CDATA[store]]></code>
     </MixedMethodCall>
     <MixedPropertyFetch>
       <code><![CDATA[$app->config]]></code>
@@ -80,13 +87,5 @@
     <UndefinedDocblockClass>
       <code><![CDATA[SimpleCacheBridge]]></code>
     </UndefinedDocblockClass>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[$this->app]]></code>
-      <code><![CDATA[$this->app]]></code>
-      <code><![CDATA[$this->app]]></code>
-    </UndefinedInterfaceMethod>
-    <UnusedClass>
-      <code><![CDATA[SwapServiceProvider]]></code>
-    </UnusedClass>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,9 +9,12 @@
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/src/Facades/Swap.php
+++ b/src/Facades/Swap.php
@@ -25,6 +25,8 @@ final class Swap extends Facade
 {
     /**
      * {@inheritdoc}
+     *
+     * @psalm-pure
      */
     protected static function getFacadeAccessor()
     {

--- a/src/SwapServiceProvider.php
+++ b/src/SwapServiceProvider.php
@@ -71,6 +71,8 @@ final class SwapServiceProvider extends ServiceProvider
      * Get the services provided by the provider.
      *
      * @return string[]
+     *
+     * @psalm-pure
      */
     public function provides()
     {


### PR DESCRIPTION
## Summary

Replace the direct `vimeo/psalm` dev dependency with `psalm/plugin-laravel` ^4.13, which pulls Psalm in transitively and teaches it about Laravel's container, facades, and service-provider APIs.

## Changes

- `composer.json`:
  - drop `vimeo/psalm: ^6.0`, add `psalm/plugin-laravel: ^4.13`.
  - set `minimum-stability: beta` + `prefer-stable: true`. Plugin 4.13 targets Psalm 7, currently published only as a beta (`7.0.0-beta19`); `prefer-stable` keeps every other dependency on its stable release.
- `psalm.xml`: register `Psalm\LaravelPlugin\Plugin`.
- `psalm-baseline.xml`: regenerated against Psalm 7. With Laravel types resolved, several entries drop out (`UndefinedInterfaceMethod` on `$this->app`, the container `store()` `MixedMethodCall`, `UnusedClass` on `SwapServiceProvider`).
- `src/Facades/Swap.php`, `src/SwapServiceProvider.php`: annotate `getFacadeAccessor()` and `provides()` with `@psalm-pure` (both return literals with no side effects), satisfying Psalm 7's new `MissingPureAnnotation` check instead of baselining it.

Psalm reports no errors against the new baseline.
