### PR TITLE
chore: add strict return types and Override attributes for Psalm 7

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,33 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
-  <file src="src/Facades/Swap.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected static function getFacadeAccessor()]]></code>
-    </MissingOverrideAttribute>
-    <UnusedClass>
-      <code><![CDATA[Swap]]></code>
-    </UnusedClass>
-  </file>
   <file src="src/SwapServiceProvider.php">
-    <InvalidArgument>
-      <code><![CDATA[$cache]]></code>
-    </InvalidArgument>
     <InvalidArrayOffset>
       <code><![CDATA[[$source => $this->getConfigPath('swap.php')]]]></code>
     </InvalidArrayOffset>
-    <InvalidReturnStatement>
-      <code><![CDATA[$store]]></code>
-    </InvalidReturnStatement>
-    <MissingClosureParamType>
-      <code><![CDATA[$app]]></code>
-    </MissingClosureParamType>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function provides()]]></code>
-      <code><![CDATA[public function register()]]></code>
-    </MissingOverrideAttribute>
-    <MissingReturnType>
-      <code><![CDATA[boot]]></code>
-    </MissingReturnType>
     <MixedArgument>
       <code><![CDATA[$app->config->get('swap.options', [])]]></code>
       <code><![CDATA[$cache]]></code>
@@ -54,9 +30,6 @@
       <code><![CDATA[get]]></code>
       <code><![CDATA[getStore]]></code>
     </MixedMethodCall>
-    <MixedPropertyFetch>
-      <code><![CDATA[$app->config]]></code>
-    </MixedPropertyFetch>
     <MixedReturnStatement>
       <code><![CDATA[$this->app[$httpClient]]]></code>
       <code><![CDATA[$this->app[$requestFactory]]]></code>
@@ -65,21 +38,19 @@
             )]]></code>
     </MixedReturnStatement>
     <NoInterfaceProperties>
+      <code><![CDATA[$app->config]]></code>
       <code><![CDATA[$this->app->config]]></code>
       <code><![CDATA[$this->app->config]]></code>
       <code><![CDATA[$this->app->config]]></code>
     </NoInterfaceProperties>
-    <NullableReturnStatement>
-      <code><![CDATA[null]]></code>
-    </NullableReturnStatement>
     <PossiblyFalseArgument>
       <code><![CDATA[$source]]></code>
     </PossiblyFalseArgument>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[null !== $cache = $this->getSimpleCache()]]></code>
-    </RedundantConditionGivenDocblockType>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$cache]]></code>
+    </PossiblyInvalidArgument>
     <UndefinedDocblockClass>
-      <code><![CDATA[SimpleCacheBridge]]></code>
+      <code><![CDATA[\Psr\SimpleCache\CacheInterface|\Cache\Bridge\SimpleCache\SimpleCacheBridge|null]]></code>
     </UndefinedDocblockClass>
   </file>
 </files>

--- a/src/Facades/Swap.php
+++ b/src/Facades/Swap.php
@@ -18,15 +18,16 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Exchanger\Contract\ExchangeRate historical(string $currencyPair, \DateTimeInterface $date, array $options = [])
  *
  * @see \Swap\Swap
+ * @api
  */
 final class Swap extends Facade
 {
     /**
      * {@inheritdoc}
-     *
      * @psalm-pure
      */
-    protected static function getFacadeAccessor()
+    #[\Override]
+    protected static function getFacadeAccessor(): string
     {
         return 'swap';
     }

--- a/src/SwapServiceProvider.php
+++ b/src/SwapServiceProvider.php
@@ -13,6 +13,7 @@ namespace Swap\Laravel;
 
 use Cache\Bridge\SimpleCache\SimpleCacheBridge;
 use Cache\Adapter\Illuminate\IlluminateCachePool;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Swap\Builder;
 
@@ -26,7 +27,7 @@ final class SwapServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application services.
      */
-    public function boot()
+    public function boot(): void
     {
         $source = realpath(__DIR__.'/../config/swap.php');
         $this->publishes([$source => $this->getConfigPath('swap.php')]);
@@ -36,9 +37,10 @@ final class SwapServiceProvider extends ServiceProvider
     /**
      * Register the application services.
      */
+    #[\Override]
     public function register()
     {
-        $this->app->singleton('swap', function ($app) {
+        $this->app->singleton('swap', function (Application $app) {
             $builder = new Builder($app->config->get('swap.options', []));
 
             if (null !== $cache = $this->getSimpleCache()) {
@@ -74,6 +76,7 @@ final class SwapServiceProvider extends ServiceProvider
      *
      * @psalm-pure
      */
+    #[\Override]
     public function provides()
     {
         return [
@@ -96,7 +99,7 @@ final class SwapServiceProvider extends ServiceProvider
     /**
      * Gets the simple cache.
      *
-     * @return SimpleCacheBridge
+     * @return \Psr\SimpleCache\CacheInterface|\Cache\Bridge\SimpleCache\SimpleCacheBridge|null
      */
     private function getSimpleCache()
     {


### PR DESCRIPTION
## What

Hardens types and method annotations so the code passes cleanly under Psalm 7, and trims the Psalm baseline to match.

- Add return types: `SwapServiceProvider::boot(): void`, `Swap::getFacadeAccessor(): string`.
- Add `#[\Override]` on overridden methods (`getFacadeAccessor`, `register`, `provides`).
- Type the `swap` singleton closure parameter as `Illuminate\Contracts\Foundation\Application`.
- Widen `getSimpleCache()` docblock to `\Psr\SimpleCache\CacheInterface|\Cache\Bridge\SimpleCache\SimpleCacheBridge|null`.
- Mark the `Swap` facade `@api` and drop a stray blank docblock line.
- Shrink `psalm-baseline.xml` to reflect the resolved issues.

## Why

Follows the Psalm 7 / `psalm/plugin-laravel` v4 modernization. These annotations remove baseline entries instead of suppressing them.